### PR TITLE
:rage: Prevent network errors from crashing logger

### DIFF
--- a/lib/loggerUtils.js
+++ b/lib/loggerUtils.js
@@ -35,10 +35,15 @@ function getStreams(environment) {
 
   if (environment === 'production') {
     requireEnv(['SPLUNK_HEC_TOKEN', 'SPLUNK_HEC_ENDPOINT']);
-    streams.push(splunkBunyan.createStream({
+    const stream = splunkBunyan.createStream({
       token: process.env.SPLUNK_HEC_TOKEN,
       url: process.env.SPLUNK_HEC_ENDPOINT,
-    }));
+    });
+    stream.on('error', () => {
+      // Purposefully left empty to swallow the error
+      // Needs something better sorting
+    });
+    streams.push(stream);
   } else {
     streams.push({ stream: process.stdout });
   }

--- a/test/unit/dep-exceptions.js
+++ b/test/unit/dep-exceptions.js
@@ -1,0 +1,33 @@
+const chai = require('chai');
+
+const expect = chai.expect;
+
+describe('dependency exceptions', () => {
+  let token;
+  let endpoint;
+
+  before('setup env vars', () => {
+    token = process.env.SPLUNK_HEC_TOKEN;
+    endpoint = process.env.SPLUNK_HEC_ENDPOINT;
+
+    process.env.SPLUNK_HEC_TOKEN = 'string';
+    process.env.SPLUNK_HEC_ENDPOINT = 'https://not.real:8088';
+    process.env.NODE_ENV = 'production';
+  });
+  after('reset env vars', () => {
+    process.env.SPLUNK_HEC_TOKEN = token;
+    process.env.SPLUNK_HEC_ENDPOINT = endpoint;
+    process.env.NODE_ENV = '';
+  });
+
+  it('should not bubble up an exception when the host is unreachable', () => {
+    // eslint-disable-next-line global-require
+    const logger = require('../../index')('dep-exception-tester');
+
+    setTimeout(() => {
+      logger.info('something');
+    }, 500);
+
+    expect(logger).to.not.be.equal(undefined);
+  });
+});

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -4,23 +4,28 @@ const AssertionError = require('assert').AssertionError;
 const expect = chai.expect;
 
 describe('logger', () => {
-  it('should be able to be named', () => {
-    const loggerName = 'logger-name';
-    // eslint-disable-next-line global-require
-    const logger = require('../../index')(loggerName);
+  describe('normal operation', () => {
+    it('should be able to be named', () => {
+      const loggerName = 'logger-name';
+      delete require.cache[require.resolve('../../index')];
+      // eslint-disable-next-line global-require
+      const logger = require('../../index')(loggerName);
 
-    expect(logger.fields.name).to.equal(loggerName);
+      expect(logger.fields.name).to.equal(loggerName);
+    });
   });
 
-  it('should throw an exception when no name is provided', () => {
-    // eslint-disable-next-line global-require
-    expect(() => { require('../../index')(); })
-    .to.throw(AssertionError, 'name must not be empty');
-  });
+  describe('internal exceptions', () => {
+    it('should throw an exception when no name is provided', () => {
+      // eslint-disable-next-line global-require
+      expect(() => { require('../../index')(); })
+      .to.throw(AssertionError, 'name must not be empty');
+    });
 
-  it('should throw an exception when an empty name is provided', () => {
-    // eslint-disable-next-line global-require
-    expect(() => { require('../../index')(''); })
-    .to.throw(AssertionError, 'name must not be empty');
+    it('should throw an exception when an empty name is provided', () => {
+      // eslint-disable-next-line global-require
+      expect(() => { require('../../index')(''); })
+      .to.throw(AssertionError, 'name must not be empty');
+    });
   });
 });


### PR DESCRIPTION
I've tested this against `connecting-to-services` and the app no longer crashes.

I'm not really sure what to do about errors when they happen. Logging out to console is not an option in production due to their synchronous nature. At least this fixes the problem for the time being and is no worse than it currently is.