### PR TITLE
:put_litter_in_its_place: Default to stdout stream

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ function log(name) {
     name,
     serializers: bunyan.stdSerializers,
     level: loggerUtils.getLogLevel(env),
-    streams: loggerUtils.getStreams(env),
+    streams: [{ stream: process.stdout }],
   });
 }
 

--- a/lib/loggerUtils.js
+++ b/lib/loggerUtils.js
@@ -1,8 +1,6 @@
 Number.isNan = require('is-nan');
 const assert = require('assert');
 const bunyan = require('bunyan');
-const splunkBunyan = require('splunk-bunyan-logger');
-const requireEnv = require('require-environment-variables');
 
 function defaultLogLevel() {
   return bunyan.DEBUG;
@@ -30,28 +28,7 @@ function getLogLevel(environment) {
   }[environment] || defaultLogLevel();
 }
 
-function getStreams(environment) {
-  const streams = [];
-
-  if (environment === 'production') {
-    requireEnv(['SPLUNK_HEC_TOKEN', 'SPLUNK_HEC_ENDPOINT']);
-    const stream = splunkBunyan.createStream({
-      token: process.env.SPLUNK_HEC_TOKEN,
-      url: process.env.SPLUNK_HEC_ENDPOINT,
-    });
-    stream.on('error', () => {
-      // Purposefully left empty to swallow the error
-      // Needs something better sorting
-    });
-    streams.push(stream);
-  } else {
-    streams.push({ stream: process.stdout });
-  }
-  return streams;
-}
-
 module.exports = {
   getLogLevel,
-  getStreams,
   defaultLogLevel,
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nhsuk-bunyan-logger",
-  "version": "0.0.1",
-  "description": "bunyan splunk logger for nhsuk apps",
+  "version": "0.1.0",
+  "description": "bunyan logger for nhsuk apps",
   "main": "index.js",
   "scripts": {
     "lint": "eslint .",
@@ -21,13 +21,15 @@
       "post-rewrite": "npm run lint && npm run generate-coverage && npm run check-coverage"
     }
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nhsuk/bunyan-logger.git"
+  },
   "author": "",
   "license": "MIT",
   "dependencies": {
     "bunyan": "^1.8.5",
     "is-nan": "^1.2.1",
-    "require-environment-variables": "^1.1.2",
-    "splunk-bunyan-logger": "^0.9.2",
     "snyk": "^1.19.1"
   },
   "devDependencies": {

--- a/test/unit/lib/loggerUtils.js
+++ b/test/unit/lib/loggerUtils.js
@@ -103,47 +103,4 @@ describe('loggerUtils', () => {
         `${wordLogLevel} is not a valid LOG_LEVEL`);
     });
   });
-
-  describe('getStreams', () => {
-    describe('for non-production environments', () => {
-      it('should return a stream to stdout for none production environments', () => {
-        const streams = utils.getStreams('not-production');
-
-        expect(streams).to.be.instanceOf(Array);
-        expect(streams.length).to.be.equal(1);
-        expect(streams[0]).to.have.property('stream', process.stdout);
-      });
-    });
-    describe('for production environments', () => {
-      beforeEach('reset SPLUNK_HEC_* vars', () => {
-        process.env.SPLUNK_HEC_TOKEN = '';
-        process.env.SPLUNK_HEC_ENDPOINT = '';
-      });
-      afterEach('reset SPLUNK_HEC_* vars', () => {
-        process.env.SPLUNK_HEC_TOKEN = '';
-        process.env.SPLUNK_HEC_ENDPOINT = '';
-      });
-
-      it('should return a splunk stream for a production environment', () => {
-        const token = 'test-token';
-        const url = 'http://some.url';
-        process.env.SPLUNK_HEC_TOKEN = token;
-        process.env.SPLUNK_HEC_ENDPOINT = url;
-
-        const streams = utils.getStreams('production');
-
-        expect(streams).to.be.instanceOf(Array);
-        expect(streams.length).to.be.equal(1);
-        expect(streams[0]).to.have.property('stream');
-        expect(streams[0]).to.not.have.property('stream', process.stdout);
-        expect(streams[0].stream).to.have.property('logger');
-      });
-
-      it('should throw an exception when env vars are missing', () => {
-        expect(() => { utils.getStreams('production'); })
-        .to.throw(Error,
-          'Environment variables missing');
-      });
-    });
-  });
 });


### PR DESCRIPTION
No longer use the `splunk-bunyan-logger` in production. Or anywhere,
completely remove it due to different way of collecting logs.

Fixes #7 